### PR TITLE
add Windows scripts

### DIFF
--- a/scripts/make_component.bat
+++ b/scripts/make_component.bat
@@ -1,0 +1,95 @@
+:: #
+:: # Copyright (c) 2019-2019 Software Architecture Group, Hasso Plattner Institute
+:: #
+:: # Licensed under the MIT License.
+:: #
+@echo off
+setlocal enabledelayedexpansion
+
+set _EXITCODE=0
+
+where /q jar.exe
+if not %ERRORLEVEL%==0 (
+    echo Could not find executable jar.exe 1>&2
+    set _EXITCODE=1
+    goto end
+)
+set _JAR_CMD=jar.exe
+
+set _LANGUAGE_ID=smalltalk
+set _GRAALVM_VERSION=19.2.0.1
+
+for %%f in ("%~dp0") do set "_BASE_DIR=%%~f"
+set "_COMPONENT_DIR=%TEMP%\component_temp_dir"
+for %%f in ("%~dp0..") do set "_GRAALSQUEAK_DIR=%%~f"
+set "_GRAALSQUEAK_JAR=%_GRAALSQUEAK_DIR%\graalsqueak.jar"
+set "_LANGUAGE_PATH=%_COMPONENT_DIR%\jre\languages\%_LANGUAGE_ID%"
+set "_LIB_GRAALVM_PATH=%_COMPONENT_DIR%\jre\lib\graalvm"
+set "_MANIFEST=%_COMPONENT_DIR%\META-INF\MANIFEST.MF"
+set "_TARGET_JAR=%_GRAALSQUEAK_DIR%\graalsqueak-component.jar"
+set _TEMPLATE_LAUNCHER=template.graalsqueak.sh
+set _TEMPLATE_WIN_LAUNCHER=template.graalsqueak.cmd
+
+if exist "%_COMPONENT_DIR%\" (
+    set /p _USER_INPUT='%_COMPONENT_DIR%' already exists. Do you want to remove it? ^(y/N^) 
+    if /i not "!_USER_INPUT!"=="y" (
+        rem we abort script execution
+        goto end
+    )
+    rmdir /s /q "%_COMPONENT_DIR%"
+)
+
+if not exist "%_GRAALSQUEAK_JAR%" (
+    echo Could not find '%_GRAALSQUEAK_JAR%'. Did you run 'mx build'?
+    set _EXITCODE=1
+    goto end
+)
+
+mkdir "%_LANGUAGE_PATH%" "%_LANGUAGE_PATH%\bin" "%_LIB_GRAALVM_PATH%"
+copy /y "%_GRAALSQUEAK_JAR%" "%_LANGUAGE_PATH%" 1>NUL
+copy /y "%_GRAALSQUEAK_DIR%\graalsqueak-shared.jar" "%_LANGUAGE_PATH%" 1>NUL
+copy /y "%_BASE_DIR%\%_TEMPLATE_LAUNCHER%" "%_LANGUAGE_PATH%\bin\graalsqueak" 1>NUL
+copy /y "%_BASE_DIR%\%_TEMPLATE_WIN_LAUNCHER%" "%_LANGUAGE_PATH%\bin\graalsqueak.cmd" 1>NUL
+copy /y "%_GRAALSQUEAK_DIR%\graalsqueak-launcher.jar" "%_LIB_GRAALVM_PATH%" 1>NUL
+
+mkdir "%_COMPONENT_DIR%\META-INF"
+
+echo Bundle-Name: GraalSqueak> "%_MANIFEST%"
+echo Bundle-Symbolic-Name: de.hpi.swa.graal.squeak>> "%_MANIFEST%"
+echo Bundle-Version: %_GRAALVM_VERSION%>> "%_MANIFEST%"
+echo Bundle-RequireCapability: org.graalvm; filter:="(&(graalvm_version=%_GRAALVM_VERSION%)(os_arch=amd64))">> "%_MANIFEST%"
+echo x-GraalVM-Polyglot-Part: True>> "%_MANIFEST%"
+
+pushd "%_COMPONENT_DIR%"
+"%_JAR_CMD%" cfm "%_TARGET_JAR%" META-INF\MANIFEST.MF .
+if not %ERRORLEVEL%==0 (
+    popd
+    echo Failed to create Java archive %_TARGET_JAR% 1>&2
+    set _EXITCODE=1
+    goto end
+)
+echo bin\graalsqueak = ..\jre\languages\%_LANGUAGE_ID%\bin\graalsqueak> META-INF\symlinks
+echo bin\graalsqueak.cmd = ..\jre\languages\%_LANGUAGE_ID%\bin\graalsqueak.cmd>> META-INF\symlinks
+"%_JAR_CMD%" uf "%_TARGET_JAR%" META-INF\symlinks
+if not %ERRORLEVEL%==0 (
+    popd
+    echo Failed to update Java archive %_TARGET_JAR% 1>&2
+    set _EXITCODE=1
+    goto end
+)
+echo jre\languages\%_LANGUAGE_ID%\bin\graalsqueak = rwxrwxr-x> META-INF\permissions
+"%_JAR_CMD%" uf "%_TARGET_JAR%" META-INF\permissions
+if not %ERRORLEVEL%==0 (
+    popd
+    echo Failed to update Java archive %_TARGET_JAR% 1>&2
+    set _EXITCODE=1
+    goto end
+)
+popd
+rmdir /s /q "%_COMPONENT_DIR%"
+
+echo SUCCESS^^! The component is located at '%_TARGET_JAR%'.
+
+:end
+exit /b %_EXITCODE%
+endlocal

--- a/scripts/make_component.sh
+++ b/scripts/make_component.sh
@@ -19,6 +19,7 @@ readonly LIB_GRAALVM_PATH="${COMPONENT_DIR}/jre/lib/graalvm"
 readonly MANIFEST="${COMPONENT_DIR}/META-INF/MANIFEST.MF"
 readonly TARGET_JAR="${GRAALSQUEAK_DIR}/graalsqueak-component.jar"
 readonly TEMPLATE_LAUNCHER="template.graalsqueak.sh"
+readonly TEMPLATE_WIN_LAUNCHER="template.graalsqueak.cmd"
 
 if [[ -d "${COMPONENT_DIR}" ]]; then
     read -p "'${COMPONENT_DIR}' already exists. Do you want to remove it? (y/N): " user_input
@@ -38,6 +39,7 @@ cp "${GRAALSQUEAK_DIR}/graalsqueak.jar" \
 	"${GRAALSQUEAK_DIR}/graalsqueak-shared.jar" \
     "${LANGUAGE_PATH}"
 cp "${BASE_DIR}/${TEMPLATE_LAUNCHER}" "${LANGUAGE_PATH}/bin/graalsqueak"
+cp "${BASE_DIR}/${TEMPLATE_WIN_LAUNCHER}" "${LANGUAGE_PATH}/bin/graalsqueak.cmd"
 cp "${GRAALSQUEAK_DIR}/graalsqueak-launcher.jar" "$LIB_GRAALVM_PATH"
 
 mkdir -p "${COMPONENT_DIR}/META-INF"

--- a/scripts/template.graalsqueak.cmd
+++ b/scripts/template.graalsqueak.cmd
@@ -9,7 +9,7 @@ setlocal enabledelayedexpansion
 set _VERSION=19.2.0.1
 
 set _MAIN_CLASS=de.hpi.swa.graal.squeak.launcher.GraalSqueakLauncher
-for %%f in ("%~dp0..\..\..\..") do set _ROOT_DIR=%%~f
+for %%f in ("%~dp0..\..\..\..") do set "_ROOT_DIR=%%~f"
 set "_LIB_DIR=%_ROOT_DIR%\jre\lib"
 
 :: #######################################################################
@@ -53,6 +53,6 @@ for %%i in ("%*") do (
         set _PROGRAM_ARGS=!_PROGRAM_ARGS! !__OPT!
     )
 )
-%_JAVACMD% %_JAVA_ARGS% -Xbootclasspath/a:%_BOOT_PATH% -cp %_LAUNCHER_PATH% %_MAIN_CLASS% %_PROGRAM_ARGS%
+"%_JAVACMD%" %_JAVA_ARGS% -Xbootclasspath/a:%_BOOT_PATH% -cp %_LAUNCHER_PATH% %_MAIN_CLASS% %_PROGRAM_ARGS%
 exit /b %ERRORLEVEL%
 endlocal

--- a/scripts/template.graalsqueak.cmd
+++ b/scripts/template.graalsqueak.cmd
@@ -1,0 +1,58 @@
+:: #
+:: # Copyright (c) 2019-2019 Software Architecture Group, Hasso Plattner Institute
+:: #
+:: # Licensed under the MIT License.
+:: #
+@echo off
+setlocal enabledelayedexpansion
+
+set _VERSION=19.2.0.1
+
+set _MAIN_CLASS=de.hpi.swa.graal.squeak.launcher.GraalSqueakLauncher
+for %%f in ("%~dp0..\..\..\..") do set _ROOT_DIR=%%~f
+set "_LIB_DIR=%_ROOT_DIR%\jre\lib"
+
+:: #######################################################################
+:: # Prepare to run as component for GraalVM.                            #
+:: #######################################################################
+set _GRAALVM_VERSION=
+if exist "%_ROOT_DIR%\release" for /f %%i in (%_ROOT_DIR%\release) do (
+    set __LINE=%%i
+    if "!__LINE:~0,15!"=="GRAALVM_VERSION" set _GRAALVM_VERSION=!__LINE:~16!
+)
+if not defined _GRAALVM_VERSION (
+    echo Could not determine Graal version 1>&2
+    exit /b 1
+) else if not "%_GRAALVM_VERSION%"=="%_VERSION%" (
+    echo Installed in wrong version of GraalVM. Expected: %_VERSION%, found %_GRAALVM_VERSION% 1>&2
+    exit /b 1
+)
+set "_BOOT_PATH=%_LIB_DIR%\boot\graal-sdk.jar;%_LIB_DIR%\truffle\truffle-api.jar"
+set "_LAUNCHER_PATH=%_LIB_DIR%\graalvm\launcher-common.jar;%_LIB_DIR%\graalvm\graalsqueak-launcher.jar"
+set "_JAVACMD=%_ROOT_DIR%\jre\bin\java.exe"
+
+:: #######################################################################
+:: # Parse arguments, prepare Java command, and execute.                 #
+:: #######################################################################
+set _PROGRAM_ARGS=--polyglot
+set _JAVA_ARGS=-Xss64M -XX:OldSize=256M -XX:NewSize=1G -XX:MetaspaceSize=32M
+
+for %%i in ("%*") do (
+    set "__OPT=%%~i"
+    if /i "!__OPT!"=="" (
+        rem ignore empty option
+    ) else if /i "!__OPT!"=="-debug" (
+        set _JAVA_ARGS=!_JAVA_ARGS! -Xdebug -Xrunjdwp:transport=dt_socket,server=y,address=8000,suspend=y
+    ) else if /i "!__OPT!"=="-dump" (
+        set _JAVA_ARGS=!_JAVA_ARGS! -Dgraal.Dump=Truffle:1 -Dgraal.TruffleBackgroundCompilation=false -Dgraal.TraceTruffleCompilation=true -Dgraal.TraceTruffleCompilationDetails=true
+    ) else if  /i "!__OPT!"=="-disassemble" (
+        set _JAVA_ARGS=!_JAVA_ARGS! -XX:CompileCommand=print,*OptimizedCallTarget.callRoot -XX:CompileCommand=exclude,*OptimizedCallTarget.callRoot -Dgraal.TruffleBackgroundCompilation=false -Dgraal.TraceTruffleCompilation=true -Dgraal.TraceTruffleCompilationDetails=true
+    ) else if /i "!__OPT:~0,2!"=="-J" (
+        set _JAVA_ARGS=!_JAVA_ARGS! !__OPT:~2!
+    ) else (
+        set _PROGRAM_ARGS=!_PROGRAM_ARGS! !__OPT!
+    )
+)
+%_JAVACMD% %_JAVA_ARGS% -Xbootclasspath/a:%_BOOT_PATH% -cp %_LAUNCHER_PATH% %_MAIN_CLASS% %_PROGRAM_ARGS%
+exit /b %ERRORLEVEL%
+endlocal


### PR DESCRIPTION
Add preliminary support for running GraalSqueak on Windows:
- Windows command script `scripts/template.graalsqueak.cmd` is adapted from [`scripts/template.graalsqueak.sh`](https://github.com/hpi-swa/graalsqueak/blob/master/scripts/template.graalsqueak.sh).
- Windows batch script `scripts/make_component.bat`is adapted from [`scripts\make_component.sh`](https://github.com/hpi-swa/graalsqueak/blob/master/scripts/make_component.sh).