### PR TITLE
Testing data setup fixes

### DIFF
--- a/docs/test-image.md
+++ b/docs/test-image.md
@@ -57,6 +57,9 @@ Utilities authorInitials: 'GraalSqueak'.
 
 TruffleObject ensureInitialized.
 
+"The DecompilerTests use this in MethodNode>>printPrimitiveOn:"
+(Smalltalk at: #StackInterpreter) initializePrimitiveTable.
+
 "Disable performance killers"
 World setAsBackground: Color black lighter.
 Morph useSoftDropShadow: false.

--- a/src/de.hpi.swa.graal.squeak.test/src/de/hpi/swa/graal/squeak/test/AbstractSqueakTestCaseWithImage.java
+++ b/src/de.hpi.swa.graal.squeak.test/src/de/hpi/swa/graal/squeak/test/AbstractSqueakTestCaseWithImage.java
@@ -19,8 +19,10 @@ import org.junit.Assume;
 import org.junit.BeforeClass;
 
 import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.TruffleLogger;
 
 import de.hpi.swa.graal.squeak.exceptions.SqueakExceptions.SqueakException;
+import de.hpi.swa.graal.squeak.image.SqueakImageContext;
 import de.hpi.swa.graal.squeak.model.ArrayObject;
 import de.hpi.swa.graal.squeak.model.NativeObject;
 import de.hpi.swa.graal.squeak.model.NilObject;
@@ -28,16 +30,22 @@ import de.hpi.swa.graal.squeak.model.PointersObject;
 import de.hpi.swa.graal.squeak.model.layout.ObjectLayouts.LINKED_LIST;
 import de.hpi.swa.graal.squeak.model.layout.ObjectLayouts.PROCESS;
 import de.hpi.swa.graal.squeak.model.layout.ObjectLayouts.PROCESS_SCHEDULER;
+import de.hpi.swa.graal.squeak.model.layout.ObjectLayouts.SPECIAL_OBJECT;
 import de.hpi.swa.graal.squeak.nodes.ExecuteTopLevelContextNode;
 import de.hpi.swa.graal.squeak.nodes.accessing.ArrayObjectNodes.ArrayObjectReadNode;
+import de.hpi.swa.graal.squeak.shared.SqueakLanguageConfig;
 
 public class AbstractSqueakTestCaseWithImage extends AbstractSqueakTestCase {
+    private static final TruffleLogger LOG = TruffleLogger.getLogger(SqueakLanguageConfig.ID, SqueakImageContext.class);
     private static final int SQUEAK_TIMEOUT_SECONDS = 60 * 2;
-    private static final int TIMEOUT_SECONDS = SQUEAK_TIMEOUT_SECONDS + 2;
+    private static final int TIMEOUT_SECONDS = SQUEAK_TIMEOUT_SECONDS + 5;
     private static final int PRIORITY_10_LIST_INDEX = 9;
+    private static final int USER_PRIORITY_LIST_INDEX = 39;
     private static final String PASSED_VALUE = "passed";
 
     private static PointersObject idleProcess;
+    private static volatile boolean isClear;     // we have to be single-threaded, so the flag can
+                                                 // be static
 
     @BeforeClass
     public static void loadTestImage() {
@@ -45,11 +53,13 @@ public class AbstractSqueakTestCaseWithImage extends AbstractSqueakTestCase {
         loadImageContext(imagePath);
         image.getOutput().println("Test image loaded from " + imagePath + "...");
         patchImageForTesting();
+        isClear = true;
     }
 
     @AfterClass
     public static void cleanUp() {
         idleProcess = null;
+        image.interrupt.reset();
         destroyImageContext();
     }
 
@@ -86,7 +96,7 @@ public class AbstractSqueakTestCaseWithImage extends AbstractSqueakTestCase {
     }
 
     private static String getPathToTestImage() {
-        final String imagePath64bit = getPathToTestImage("test-64bit.image");
+        final String imagePath64bit = getPathToTestImage("test-64bit.1.image");
         if (imagePath64bit != null) {
             return imagePath64bit;
         }
@@ -120,6 +130,7 @@ public class AbstractSqueakTestCaseWithImage extends AbstractSqueakTestCase {
     protected static Object evaluate(final String expression) {
         context.enter();
         try {
+            LOG.fine(() -> "\nEvaluating " + expression + image.currentState());
             ensureCleanImageState();
             final ExecuteTopLevelContextNode doItContextNode = image.getDoItContextNode(expression);
             return Truffle.getRuntime().createCallTarget(doItContextNode).call();
@@ -129,48 +140,126 @@ public class AbstractSqueakTestCaseWithImage extends AbstractSqueakTestCase {
     }
 
     private static void ensureCleanImageState() {
-        image.interrupt.reset();
         if (idleProcess != null) {
             if (idleProcess.instVarAt0Slow(PROCESS.NEXT_LINK) != NilObject.SINGLETON) {
                 image.printToStdErr("Resetting dirty idle process...");
                 idleProcess.instVarAtPut0Slow(PROCESS.NEXT_LINK, NilObject.SINGLETON);
             }
             resetProcessLists();
+            resetSemaphoreLists();
+            ensureTimerLoop();
+            ensureUserProcessForTesting();
+            LOG.fine(() -> "After ensuring clean image state" + image.currentState());
         }
     }
 
     private static void resetProcessLists() {
         final Object[] lists = ((ArrayObject) image.getScheduler().instVarAt0Slow(PROCESS_SCHEDULER.PROCESS_LISTS)).getObjectStorage();
         for (int i = 0; i < lists.length; i++) {
-            final PointersObject linkedList = (PointersObject) lists[i];
+            final Object expectedValue = i == PRIORITY_10_LIST_INDEX ? idleProcess : NilObject.SINGLETON;
+            resetList(expectedValue, lists[i], "scheduler list #" + (i + 1));
+        }
+    }
+
+    private static void resetSemaphoreLists() {
+        image.interrupt.reset();
+        final Object interruptSema = image.getSpecialObject(SPECIAL_OBJECT.THE_INTERRUPT_SEMAPHORE);
+        resetList(NilObject.SINGLETON, interruptSema, "Interrupt semaphore");
+        // The timer semaphore is taken care of in ensureTimerLoop, since the delays need to be
+        // reset as well
+        final ArrayObject oldExternalObjects = (ArrayObject) image.getSpecialObject(SPECIAL_OBJECT.EXTERNAL_OBJECTS_ARRAY);
+        image.evaluate("[ ExternalObjectTable current " +
+                        "            initializeCaches;" +
+                        "            externalObjectsArray: (Smalltalk specialObjectsArray at: 39 put: (Array new: 20)) ] value");
+        final ArrayObject externalObjects = (ArrayObject) image.getSpecialObject(SPECIAL_OBJECT.EXTERNAL_OBJECTS_ARRAY);
+        assert oldExternalObjects.getSqueakHash() != externalObjects.getSqueakHash();
+    }
+
+    private static void resetList(final Object newValue, final Object listOrNil, final String linkedListName) {
+        if (listOrNil instanceof PointersObject) {
+            final PointersObject linkedList = (PointersObject) listOrNil;
             final Object key = linkedList.instVarAt0Slow(LINKED_LIST.FIRST_LINK);
             final Object value = linkedList.instVarAt0Slow(LINKED_LIST.LAST_LINK);
-            final Object expectedValue = i == PRIORITY_10_LIST_INDEX ? idleProcess : NilObject.SINGLETON;
-            if (key != expectedValue || value != expectedValue) {
-                image.printToStdErr(String.format("Removing inconsistent entry (%s->%s) from scheduler list #%s...", key, value, i + 1));
-                linkedList.instVarAtPut0Slow(LINKED_LIST.FIRST_LINK, expectedValue);
-                linkedList.instVarAtPut0Slow(LINKED_LIST.LAST_LINK, expectedValue);
+            if (key != newValue || value != newValue) {
+                LOG.severe(String.format("Removing inconsistent entry (%s->%s) from %s...", key, value, linkedListName));
+                linkedList.instVarAtPut0Slow(LINKED_LIST.FIRST_LINK, newValue);
+                linkedList.instVarAtPut0Slow(LINKED_LIST.LAST_LINK, newValue);
             }
+        }
+    }
+
+    private static void ensureTimerLoop() {
+        image.evaluate("[(Delay classPool at: #SuspendedDelays ifAbsent: [OrderedCollection new]) removeAll. " +
+                        "Delay classPool at: #ScheduledDelay put: nil; at: #FinishedDelay put: nil; at: #ActiveDelay put: nil. " +
+                        "Delay startTimerEventLoop] value");
+    }
+
+    private static void ensureUserProcessForTesting() {
+        final PointersObject activeProcess = image.getActiveProcessSlow();
+        final long activePriority = (long) activeProcess.instVarAt0Slow(PROCESS.PRIORITY);
+        if (activePriority == USER_PRIORITY_LIST_INDEX + 1) {
+            return;
+        }
+        LOG.severe(() -> "STARTING ACTIVE PROCESS @" + activeProcess.hashCode() + " PRIORITY WAS: " + activePriority + image.currentState());
+        final PointersObject newProcess = new PointersObject(image, image.processClass);
+        newProcess.instVarAtPut0Slow(PROCESS.PRIORITY, Long.valueOf(USER_PRIORITY_LIST_INDEX + 1));
+        image.getScheduler().instVarAtPut0Slow(PROCESS_SCHEDULER.ACTIVE_PROCESS, newProcess);
+
+        if (activePriority == PRIORITY_10_LIST_INDEX + 1) {
+            assert activeProcess == idleProcess;
+            LOG.severe(() -> "IDLE PROCESS IS ACTIVE, REINSTALL IT (ProcessorScheduler installIdleProcess)");
+            image.evaluate("ProcessorScheduler installIdleProcess");
+            final ArrayObject lists = (ArrayObject) image.getScheduler().instVarAt0Slow(PROCESS_SCHEDULER.PROCESS_LISTS);
+            final PointersObject priority10List = (PointersObject) ArrayObjectReadNode.getUncached().execute(lists, PRIORITY_10_LIST_INDEX);
+            final Object firstLink = priority10List.instVarAt0Slow(LINKED_LIST.FIRST_LINK);
+            final Object lastLink = priority10List.instVarAt0Slow(LINKED_LIST.LAST_LINK);
+            assert firstLink instanceof PointersObject && firstLink == lastLink &&
+                            ((PointersObject) firstLink).instVarAt0Slow(PROCESS.NEXT_LINK) == NilObject.SINGLETON : "Unexpected idleProcess state";
+            idleProcess = (PointersObject) firstLink;
+            LOG.fine(() -> image.currentState());
+            return;
         }
     }
 
     protected static void patchMethod(final String className, final String selector, final String body) {
         image.getOutput().println("Patching " + className + ">>#" + selector + "...");
-        final Object patchResult = evaluate(String.join(" ",
-                        className, "addSelectorSilently:", "#" + selector, "withMethod: (", className, "compile: '" + body + "'",
-                        "notifying: nil trailer: (CompiledMethodTrailer empty) ifFail: [^ nil]) method"));
-        assertNotEquals(NilObject.SINGLETON, patchResult);
+        context.enter();
+        try {
+            final Object patchResult = image.evaluate(String.join(" ",
+                            className, "addSelectorSilently:", "#" + selector, "withMethod: (", className, "compile: '" + body + "'",
+                            "notifying: nil trailer: (CompiledMethodTrailer empty) ifFail: [^ nil]) method"));
+            assertNotEquals(NilObject.SINGLETON, patchResult);
+        } finally {
+            context.leave();
+        }
     }
 
     protected static TestResult runTestCase(final TestRequest request) {
-        return runWithTimeout(request, () -> {
-            context.enter();
-            try {
-                return extractFailuresAndErrorsFromTestResult(request);
-            } finally {
-                context.leave();
+        if (!isClear) {
+            throw new IllegalStateException("The previous test case has not finished yet");
+        }
+        try {
+            return runWithTimeout(request, () -> {
+                isClear = false;
+                LOG.fine(() -> "\nRunning test " + request.testCase + ">>" + request.testSelector);
+                context.enter();
+                try {
+                    return extractFailuresAndErrorsFromTestResult(request);
+                } finally {
+                    context.leave();
+                    isClear = true;
+                }
+            });
+        } finally {
+            if (!isClear) {
+                image.printToStdErr("The worker thread has not finished running, we have to close it");
+                if (!request.reloadImageOnException) {
+                    // regardless of what the request says, we need to clean up.
+                    cleanUp();
+                    loadTestImage();
+                }
             }
-        });
+        }
     }
 
     private static TestResult extractFailuresAndErrorsFromTestResult(final TestRequest request) {
@@ -183,7 +272,7 @@ public class AbstractSqueakTestCaseWithImage extends AbstractSqueakTestCase {
             assert ((NativeObject) result).isByteType() : "Passing result should always be a ByteString";
             return TestResult.success(testResult);
         } else {
-            final boolean shouldPass = (boolean) evaluate(shouldPassCommand(request));
+            final boolean shouldPass = (boolean) image.evaluate(shouldPassCommand(request));
             if (shouldPass) {
                 return TestResult.failure(testResult);
             } else {

--- a/src/de.hpi.swa.graal.squeak.test/src/de/hpi/swa/graal/squeak/test/AbstractSqueakTestCaseWithImage.java
+++ b/src/de.hpi.swa.graal.squeak.test/src/de/hpi/swa/graal/squeak/test/AbstractSqueakTestCaseWithImage.java
@@ -96,7 +96,7 @@ public class AbstractSqueakTestCaseWithImage extends AbstractSqueakTestCase {
     }
 
     private static String getPathToTestImage() {
-        final String imagePath64bit = getPathToTestImage("test-64bit.1.image");
+        final String imagePath64bit = getPathToTestImage("test-64bit.image");
         if (imagePath64bit != null) {
             return imagePath64bit;
         }

--- a/src/de.hpi.swa.graal.squeak.test/src/de/hpi/swa/graal/squeak/test/SqueakMiscellaneousTest.java
+++ b/src/de.hpi.swa.graal.squeak.test/src/de/hpi/swa/graal/squeak/test/SqueakMiscellaneousTest.java
@@ -27,7 +27,7 @@ import de.hpi.swa.graal.squeak.util.CompiledCodeObjectPrinter;
 import de.hpi.swa.graal.squeak.util.SqueakBytecodeDecoder;
 
 public class SqueakMiscellaneousTest extends AbstractSqueakTestCaseWithDummyImage {
-    private static final String ALL_BYTECODES_EXPECTED_RESULT = String.join("\n", "1 <0F> pushRcvr: 15",
+    private static final String ALL_BYTECODES_EXPECTED_RESULT = String.join("\n", "1 <8B 1F 00> callPrimitive: 31",
                     "2 <1F> pushTemp: 15",
                     "3 <20> pushConstant: someSelector",
                     "4 <5F> pushLit: 31",
@@ -63,7 +63,7 @@ public class SqueakMiscellaneousTest extends AbstractSqueakTestCaseWithDummyImag
                     "34 <88> dup",
                     "35 <89> pushThisContext:",
                     "36 <8A 1F> push: (Array new: 31)",
-                    "37 <8B 1F 00> callPrimitive: 31",
+                    "37 <0F> pushRcvr: 15",
                     "38 <8C 1F 38> pushTemp: 31 inVectorAt: 56",
                     "39 <8D 1F 38> storeIntoTemp: 31 inVectorAt: 56",
                     "40 <8E 1F 38> popIntoTemp: 31 inVectorAt: 56",
@@ -157,7 +157,8 @@ public class SqueakMiscellaneousTest extends AbstractSqueakTestCaseWithDummyImag
     public void testSourceAllBytecodes() {
         final Object[] literals = new Object[]{17235971L, image.asByteString("someSelector"), image.asByteString("someOtherSelector"), 63};
         final CompiledCodeObject code = makeMethod(literals,
-                        15, 31, 32, 95, 96, 97, 98, 99, 103, 111, 112, 113, 114, 115, 116,
+                        139, 31, 0,
+                        31, 32, 95, 96, 97, 98, 99, 103, 111, 112, 113, 114, 115, 116,
                         117, 118, 119, 120, 121, 122, 123, 124, 126, 127,
                         128, 31,
                         129, 31,
@@ -170,7 +171,7 @@ public class SqueakMiscellaneousTest extends AbstractSqueakTestCaseWithDummyImag
                         136,
                         137,
                         138, 31,
-                        139, 31, 0,
+                        15,
                         140, 31, CONTEXT.LARGE_FRAMESIZE,
                         141, 31, CONTEXT.LARGE_FRAMESIZE,
                         142, 31, CONTEXT.LARGE_FRAMESIZE,

--- a/src/de.hpi.swa.graal.squeak/src/de/hpi/swa/graal/squeak/image/SqueakImageContext.java
+++ b/src/de.hpi.swa.graal.squeak/src/de/hpi/swa/graal/squeak/image/SqueakImageContext.java
@@ -19,6 +19,7 @@ import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.TruffleLogger;
 import com.oracle.truffle.api.frame.Frame;
 import com.oracle.truffle.api.frame.FrameInstance;
 import com.oracle.truffle.api.instrumentation.AllocationReporter;
@@ -50,9 +51,11 @@ import de.hpi.swa.graal.squeak.model.PointersObject;
 import de.hpi.swa.graal.squeak.model.layout.ObjectLayouts.ASSOCIATION;
 import de.hpi.swa.graal.squeak.model.layout.ObjectLayouts.CONTEXT;
 import de.hpi.swa.graal.squeak.model.layout.ObjectLayouts.ENVIRONMENT;
+import de.hpi.swa.graal.squeak.model.layout.ObjectLayouts.LINKED_LIST;
 import de.hpi.swa.graal.squeak.model.layout.ObjectLayouts.MESSAGE;
 import de.hpi.swa.graal.squeak.model.layout.ObjectLayouts.PROCESS;
 import de.hpi.swa.graal.squeak.model.layout.ObjectLayouts.PROCESS_SCHEDULER;
+import de.hpi.swa.graal.squeak.model.layout.ObjectLayouts.SEMAPHORE;
 import de.hpi.swa.graal.squeak.model.layout.ObjectLayouts.SMALLTALK_IMAGE;
 import de.hpi.swa.graal.squeak.model.layout.ObjectLayouts.SPECIAL_OBJECT;
 import de.hpi.swa.graal.squeak.model.layout.SlotLocation;
@@ -75,6 +78,7 @@ import de.hpi.swa.graal.squeak.util.MiscUtils;
 import de.hpi.swa.graal.squeak.util.OSDetector;
 
 public final class SqueakImageContext {
+    private static final TruffleLogger LOG = TruffleLogger.getLogger(SqueakLanguageConfig.ID, SqueakImageContext.class);
     /* Special objects */
     public final ClassObject trueClass = new ClassObject(this);
     public final ClassObject falseClass = new ClassObject(this);
@@ -92,8 +96,8 @@ public final class SqueakImageContext {
     public final ClassObject compiledMethodClass = new ClassObject(this);
     public final ClassObject semaphoreClass = new ClassObject(this);
     public final ClassObject characterClass = new ClassObject(this);
-    public final NativeObject doesNotUnderstand = new NativeObject(this);
     public final NativeObject cannotReturn = new NativeObject(this);
+    public final NativeObject doesNotUnderstand = new NativeObject(this);
     public final NativeObject mustBeBooleanSelector = new NativeObject(this);
     public final ClassObject byteArrayClass = new ClassObject(this);
     public final ClassObject processClass = new ClassObject(this);
@@ -178,6 +182,7 @@ public final class SqueakImageContext {
             // Load image.
             SqueakImageReader.load(this);
             getOutput().println("Preparing image for headless execution...");
+            LOG.fine(() -> "Fresh after load" + currentState());
             // Remove active context.
             getActiveProcessSlow().instVarAtPut0Slow(PROCESS.SUSPENDED_CONTEXT, NilObject.SINGLETON);
             // Modify StartUpList for headless execution.
@@ -194,6 +199,7 @@ public final class SqueakImageContext {
             evaluate("Utilities setAuthorInitials: 'GraalSqueak'");
             // Initialize fresh MorphicUIManager.
             evaluate("Project current instVarNamed: #uiManager put: MorphicUIManager new");
+            LOG.fine(() -> "After startup" + currentState());
         }
     }
 
@@ -216,6 +222,7 @@ public final class SqueakImageContext {
     public Object evaluate(final String sourceCode) {
         CompilerAsserts.neverPartOfCompilation("For testing or instrumentation only.");
         final Source source = Source.newBuilder(SqueakLanguageConfig.NAME, sourceCode, "<image#evaluate>").build();
+        LOG.fine(() -> "Evaluating " + sourceCode + "\n");
         return Truffle.getRuntime().createCallTarget(getDoItContextNode(source)).call();
     }
 
@@ -575,6 +582,80 @@ public final class SqueakImageContext {
         if (lastSender[0] instanceof ContextObject) {
             getError().println("== Squeak frames ================================================================");
             ((ContextObject) lastSender[0]).printSqStackTrace();
+        }
+    }
+
+    public String currentState() {
+        final StringBuilder b = new StringBuilder();
+        b.append("\nImage processes state\n");
+        final PointersObject activeProcess = getActiveProcessSlow();
+        final long activePriority = (long) activeProcess.instVarAt0Slow(PROCESS.PRIORITY);
+        b.append("Active process @");
+        b.append(activeProcess.hashCode());
+        b.append(" priority ");
+        b.append(activePriority);
+        b.append('\n');
+        final Object interruptSema = getSpecialObject(SPECIAL_OBJECT.THE_INTERRUPT_SEMAPHORE);
+        printSemaphoreOrNil(b, "Interrupt semaphore @", interruptSema, true);
+        final Object timerSema = getSpecialObject(SPECIAL_OBJECT.THE_TIMER_SEMAPHORE);
+        printSemaphoreOrNil(b, "Timer semaphore @", timerSema, true);
+        final ArrayObject externalObjects = (ArrayObject) getSpecialObject(SPECIAL_OBJECT.EXTERNAL_OBJECTS_ARRAY);
+        if (!externalObjects.isEmptyType()) {
+            final Object[] semaphores = externalObjects.getObjectStorage();
+            for (int i = 0; i < semaphores.length; i++) {
+                printSemaphoreOrNil(b, "External semaphore at index " + (i + 1) + " @", semaphores[i], false);
+            }
+        }
+        final Object[] lists = ((ArrayObject) getScheduler().instVarAt0Slow(PROCESS_SCHEDULER.PROCESS_LISTS)).getObjectStorage();
+        for (int i = 0; i < lists.length; i++) {
+            printLinkedList(b, "Quiescent processes list at priority " + (i + 1), (PointersObject) lists[i]);
+        }
+        return b.toString();
+    }
+
+    private static void printSemaphoreOrNil(final StringBuilder b, final String label, final Object semaphoreOrNil, final boolean printIfNil) {
+        if (semaphoreOrNil instanceof PointersObject) {
+            b.append(label);
+            b.append(semaphoreOrNil.hashCode());
+            b.append(" with ");
+            b.append(((PointersObject) semaphoreOrNil).instVarAt0Slow(SEMAPHORE.EXCESS_SIGNALS));
+            b.append(" excess signals");
+            if (!printLinkedList(b, "", (PointersObject) semaphoreOrNil)) {
+                b.append(" and no processes\n");
+            }
+        } else {
+            if (printIfNil) {
+                b.append(label);
+                b.append(" is nil\n");
+            }
+        }
+    }
+
+    private static boolean printLinkedList(final StringBuilder b, final String label, final PointersObject linkedList) {
+        Object temp = linkedList.instVarAt0Slow(LINKED_LIST.FIRST_LINK);
+        if (temp instanceof PointersObject) {
+            b.append(label);
+            b.append(" and processes:\n");
+            while (temp instanceof PointersObject) {
+                final PointersObject aProcess = (PointersObject) temp;
+                final Object aContext = aProcess.instVarAt0Slow(PROCESS.SUSPENDED_CONTEXT);
+                if (aContext instanceof ContextObject) {
+                    b.append("\tprocess @");
+                    b.append(aProcess.hashCode());
+                    b.append(" with suspended context ");
+                    b.append(aContext);
+                    b.append(" and stack trace:\n");
+                    ((ContextObject) aContext).printSqMaterializedStackTraceOn(b);
+                } else {
+                    b.append("\tprocess @");
+                    b.append(aProcess.hashCode());
+                    b.append(" with suspended context nil\n");
+                }
+                temp = aProcess.instVarAt0Slow(PROCESS.NEXT_LINK);
+            }
+            return true;
+        } else {
+            return false;
         }
     }
 


### PR DESCRIPTION
The bytecodes for primitive calls can only be at position 0 (1 in Smalltalk), rearrange the test data to avoid the error

Also the DecompilerTests end up using the StackInterpreter, which is loaded but not initialized in the current test image - this is a documentation-only fix though, it needs to be accompanied by the upload of a new test image with the initialization performed


The second commit deals with the scenario discussed about timeouts leaving both the state of the image in a bad state, and current worker threads still running. While this could be dealt with by stopping the entire suite from running, it is convenient for developers to be able to run the whole suite in one go and gather all failures. The code does reload the image in such cases (external timeouts), but otherwise it just does a more thorough cleanup of the state of the running image