### PR TITLE
this fixes the cannotReturn implementation and adds a couple of tests for it.

### DIFF
--- a/src/de.hpi.swa.graal.squeak.test/src/de/hpi/swa/graal/squeak/test/SqueakBasicImageTest.java
+++ b/src/de.hpi.swa.graal.squeak.test/src/de/hpi/swa/graal/squeak/test/SqueakBasicImageTest.java
@@ -129,4 +129,20 @@ public class SqueakBasicImageTest extends AbstractSqueakTestCaseWithImage {
             fail(e.toString());
         }
     }
+
+    @Test
+    public void test13CannotReturnAtStart() {
+        assertEquals("bla2", evaluate("| result | \n" +
+                        "[ result := [^'bla1'] on: BlockCannotReturn do: [:e | 'bla2' ]] fork. \n" +
+                        "Processor yield.\n" +
+                        "result").toString());
+    }
+
+    @Test
+    public void test14CannotReturnInTheMiddle() {
+        assertEquals("bla2", evaluate("| result | \n" +
+                        "[ result := [thisContext yourself. ^'bla1'] on: BlockCannotReturn do: [:e | 'bla2' ]] fork. \n" +
+                        "Processor yield.\n" +
+                        "result").toString());
+    }
 }

--- a/src/de.hpi.swa.graal.squeak/src/de/hpi/swa/graal/squeak/image/SqueakImageContext.java
+++ b/src/de.hpi.swa.graal.squeak/src/de/hpi/swa/graal/squeak/image/SqueakImageContext.java
@@ -256,8 +256,8 @@ public final class SqueakImageContext {
         final ContextObject doItContext = ContextObject.create(this, doItMethod.getSqueakContextSize());
         doItContext.atput0(CONTEXT.METHOD, doItMethod);
         doItContext.atput0(CONTEXT.INSTRUCTION_POINTER, (long) doItMethod.getInitialPC());
-        doItContext.atput0(CONTEXT.RECEIVER, nilClass);
-        doItContext.atput0(CONTEXT.STACKPOINTER, 0L);
+        doItContext.atput0(CONTEXT.RECEIVER, NilObject.SINGLETON);
+        doItContext.atput0(CONTEXT.STACKPOINTER, new Long(doItMethod.getNumTemps()));
         doItContext.atput0(CONTEXT.CLOSURE_OR_NIL, NilObject.SINGLETON);
         doItContext.atput0(CONTEXT.SENDER_OR_NIL, NilObject.SINGLETON);
         return ExecuteTopLevelContextNode.create(getLanguage(), doItContext, false);

--- a/src/de.hpi.swa.graal.squeak/src/de/hpi/swa/graal/squeak/image/SqueakImageContext.java
+++ b/src/de.hpi.swa.graal.squeak/src/de/hpi/swa/graal/squeak/image/SqueakImageContext.java
@@ -11,6 +11,8 @@ import java.lang.ref.ReferenceQueue;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.graalvm.collections.EconomicMap;
 
@@ -160,6 +162,8 @@ public final class SqueakImageContext {
     @CompilationFinal(dimensions = 1) public static final byte[] DEBUG_SYNTAX_ERROR_SELECTOR_NAME = "debugSyntaxError:".getBytes();
     @CompilationFinal private NativeObject debugSyntaxErrorSelector = null;
 
+    public Map<PointersObject, ContextObject> suspendedContexts = new HashMap<>();
+
     public SqueakImageContext(final SqueakLanguage squeakLanguage, final SqueakLanguage.Env environment) {
         language = squeakLanguage;
         patch(environment);
@@ -260,6 +264,7 @@ public final class SqueakImageContext {
         doItContext.atput0(CONTEXT.STACKPOINTER, new Long(doItMethod.getNumTemps()));
         doItContext.atput0(CONTEXT.CLOSURE_OR_NIL, NilObject.SINGLETON);
         doItContext.atput0(CONTEXT.SENDER_OR_NIL, NilObject.SINGLETON);
+        doItContext.setProcess(getActiveProcessSlow());
         return ExecuteTopLevelContextNode.create(getLanguage(), doItContext, false);
     }
 
@@ -350,6 +355,19 @@ public final class SqueakImageContext {
 
     public void initializeAfterLoadingImage() {
         primitiveNodeFactory.initialize(this);
+        initializeContexts();
+    }
+
+    private void initializeContexts() {
+        for (final PointersObject p : suspendedContexts.keySet()) {
+            AbstractSqueakObject currentContext = suspendedContexts.get(p);
+            while (currentContext != NilObject.SINGLETON) {
+                final ContextObject context = (ContextObject) currentContext;
+                context.setProcess(p);
+                currentContext = context.getSender();
+            }
+        }
+        suspendedContexts.clear();
     }
 
     public ClassObject initializeTruffleObject() {

--- a/src/de.hpi.swa.graal.squeak/src/de/hpi/swa/graal/squeak/model/ContextObject.java
+++ b/src/de.hpi.swa.graal.squeak/src/de/hpi/swa/graal/squeak/model/ContextObject.java
@@ -35,6 +35,7 @@ import de.hpi.swa.graal.squeak.util.MiscUtils;
 
 public final class ContextObject extends AbstractSqueakObjectWithHash {
     @CompilationFinal private MaterializedFrame truffleFrame;
+    @CompilationFinal private PointersObject process;
     @CompilationFinal private int size;
     private boolean hasModifiedSender = false;
     private boolean escaped = false;
@@ -537,6 +538,7 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
         writeNode.execute(scheduler, PROCESS_SCHEDULER.ACTIVE_PROCESS, newProcess);
         writeNode.execute(currentProcess, PROCESS.SUSPENDED_CONTEXT, this);
         final ContextObject newActiveContext = (ContextObject) readNode.execute(newProcess, PROCESS.SUSPENDED_CONTEXT);
+        newActiveContext.setProcess(newProcess);
         writeNode.execute(newProcess, PROCESS.SUSPENDED_CONTEXT, NilObject.SINGLETON);
         if (CompilerDirectives.isPartialEvaluationConstant(newActiveContext)) {
             throw ProcessSwitch.create(newActiveContext);
@@ -608,5 +610,14 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
                 tracer.addIfUnmarked(atTemp(i));
             }
         }
+    }
+
+    public PointersObject getProcess() {
+        return process;
+    }
+
+    public void setProcess(final PointersObject process) {
+        assert process != null && (this.process == null || this.process == process);
+        this.process = process;
     }
 }

--- a/src/de.hpi.swa.graal.squeak/src/de/hpi/swa/graal/squeak/model/PointersObject.java
+++ b/src/de.hpi.swa.graal.squeak/src/de/hpi/swa/graal/squeak/model/PointersObject.java
@@ -54,6 +54,15 @@ public final class PointersObject extends AbstractPointersObject {
             writeNode.execute(this, i, pointersObject[i]);
         }
         assert size() == pointersObject.length;
+        if (getSqueakClass() == image.processClass) {
+            collectSuspendedContext();
+        }
+    }
+
+    private void collectSuspendedContext() {
+        final AbstractPointersObjectReadNode readNode = AbstractPointersObjectReadNode.getUncached();
+        final ContextObject suspendedContext = (ContextObject) readNode.execute(this, PROCESS.SUSPENDED_CONTEXT);
+        image.suspendedContexts.put(this, suspendedContext);
     }
 
     public void become(final PointersObject other) {

--- a/src/de.hpi.swa.graal.squeak/src/de/hpi/swa/graal/squeak/nodes/DispatchEagerlyNode.java
+++ b/src/de.hpi.swa.graal.squeak/src/de/hpi/swa/graal/squeak/nodes/DispatchEagerlyNode.java
@@ -25,6 +25,7 @@ import de.hpi.swa.graal.squeak.util.FrameAccess;
 @NodeInfo(cost = NodeCost.NONE)
 public abstract class DispatchEagerlyNode extends AbstractNodeWithCode {
     protected static final int INLINE_CACHE_SIZE = 6;
+    protected static final boolean TRUE = true;
 
     protected DispatchEagerlyNode(final CompiledCodeObject code) {
         super(code);
@@ -57,7 +58,7 @@ public abstract class DispatchEagerlyNode extends AbstractNodeWithCode {
                     limit = "INLINE_CACHE_SIZE", assumptions = {"cachedMethod.getCallTargetStable()"}, replaces = {"doPrimitiveEagerly"})
     protected static final Object doDirectWithSender(final VirtualFrame frame, @SuppressWarnings("unused") final CompiledMethodObject method, final Object[] receiverAndArguments,
                     @SuppressWarnings("unused") @Cached("method") final CompiledMethodObject cachedMethod,
-                    @Cached("create(code)") final GetOrCreateContextNode getOrCreateContextNode,
+                    @Cached("create(code, TRUE)") final GetOrCreateContextNode getOrCreateContextNode,
                     @Cached("create(cachedMethod.getCallTarget())") final DirectCallNode callNode) {
         return callDirect(callNode, cachedMethod, getOrCreateContextNode.executeGet(frame), receiverAndArguments);
     }
@@ -70,7 +71,7 @@ public abstract class DispatchEagerlyNode extends AbstractNodeWithCode {
 
     @Specialization(guards = "!method.getDoesNotNeedSenderAssumption().isValid()", replaces = {"doDirect", "doDirectWithSender"})
     protected static final Object doIndirectWithSender(final VirtualFrame frame, final CompiledMethodObject method, final Object[] receiverAndArguments,
-                    @Cached("create(code)") final GetOrCreateContextNode getOrCreateContextNode,
+                    @Cached("create(code, TRUE)") final GetOrCreateContextNode getOrCreateContextNode,
                     @Cached final IndirectCallNode callNode) {
         return callIndirect(callNode, method, getOrCreateContextNode.executeGet(frame), receiverAndArguments);
     }

--- a/src/de.hpi.swa.graal.squeak/src/de/hpi/swa/graal/squeak/nodes/MaterializeContextOnMethodExitNode.java
+++ b/src/de.hpi.swa.graal.squeak/src/de/hpi/swa/graal/squeak/nodes/MaterializeContextOnMethodExitNode.java
@@ -14,6 +14,8 @@ import de.hpi.swa.graal.squeak.model.CompiledCodeObject;
 import de.hpi.swa.graal.squeak.model.ContextObject;
 
 public abstract class MaterializeContextOnMethodExitNode extends AbstractNodeWithCode {
+    protected static final boolean TRUE = true;
+
     protected MaterializeContextOnMethodExitNode(final CompiledCodeObject code) {
         super(code);
     }
@@ -33,7 +35,7 @@ public abstract class MaterializeContextOnMethodExitNode extends AbstractNodeWit
     protected final void doMaterialize(final VirtualFrame frame,
                     @Cached("createBinaryProfile()") final ConditionProfile isNotLastSeenContextProfile,
                     @Cached("createBinaryProfile()") final ConditionProfile continueProfile,
-                    @Cached("create(code)") final GetOrCreateContextNode getOrCreateContextNode) {
+                    @Cached("create(code, TRUE)") final GetOrCreateContextNode getOrCreateContextNode) {
         final ContextObject lastSeenContext = code.image.lastSeenContext;
         final ContextObject context = getOrCreateContextNode.executeGet(frame);
         if (isNotLastSeenContextProfile.profile(context != lastSeenContext)) {

--- a/src/de.hpi.swa.graal.squeak/src/de/hpi/swa/graal/squeak/nodes/ResumeContextNode.java
+++ b/src/de.hpi.swa.graal.squeak/src/de/hpi/swa/graal/squeak/nodes/ResumeContextNode.java
@@ -6,7 +6,6 @@
 package de.hpi.swa.graal.squeak.nodes;
 
 import com.oracle.truffle.api.CompilerAsserts;
-import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -16,15 +15,12 @@ import com.oracle.truffle.api.nodes.NodeInfo;
 import com.oracle.truffle.api.nodes.RootNode;
 
 import de.hpi.swa.graal.squeak.SqueakLanguage;
-import de.hpi.swa.graal.squeak.exceptions.SqueakExceptions.SqueakException;
 import de.hpi.swa.graal.squeak.model.CompiledCodeObject;
 import de.hpi.swa.graal.squeak.model.ContextObject;
-import de.hpi.swa.graal.squeak.model.NilObject;
 
 @NodeInfo(cost = NodeCost.NONE)
 public abstract class ResumeContextNode extends Node {
     @Child private ExecuteContextNode executeContextNode;
-    @Child private SendSelectorNode cannotReturnNode;
 
     protected ResumeContextNode(final CompiledCodeObject code) {
         executeContextNode = ExecuteContextNode.create(code, true);
@@ -43,20 +39,6 @@ public abstract class ResumeContextNode extends Node {
     protected final Object doResumeInMiddle(final ContextObject context) {
         final long initialPC = context.getInstructionPointerForBytecodeLoop();
         return executeContextNode.executeResumeInMiddle(context.getTruffleFrame(), initialPC);
-    }
-
-    @Specialization(guards = "context.getInstructionPointerForBytecodeLoop() < 0")
-    protected final Object doCannotReturn(final ContextObject context) {
-        getCannotReturnNode().executeSend(context.getTruffleFrame(), new Object[]{context, NilObject.SINGLETON});
-        throw SqueakException.create("Should not be reached");
-    }
-
-    private SendSelectorNode getCannotReturnNode() {
-        if (cannotReturnNode == null) {
-            CompilerDirectives.transferToInterpreterAndInvalidate();
-            cannotReturnNode = insert(SendSelectorNode.create(executeContextNode.code, executeContextNode.code.image.cannotReturn));
-        }
-        return cannotReturnNode;
     }
 
     @NodeInfo(cost = NodeCost.NONE)

--- a/src/de.hpi.swa.graal.squeak/src/de/hpi/swa/graal/squeak/nodes/bytecodes/PushBytecodes.java
+++ b/src/de.hpi.swa.graal.squeak/src/de/hpi/swa/graal/squeak/nodes/bytecodes/PushBytecodes.java
@@ -55,7 +55,7 @@ public final class PushBytecodes {
 
         public PushActiveContextNode(final CompiledCodeObject code, final int index) {
             super(code, index);
-            getContextNode = GetOrCreateContextNode.create(code);
+            getContextNode = GetOrCreateContextNode.create(code, true);
         }
 
         @Override
@@ -89,7 +89,7 @@ public final class PushBytecodes {
             blockSize = j << 8 | k;
             popNNode = FrameStackPopNNode.create(code, numCopied);
             pushNode = FrameStackPushNode.create(code);
-            getOrCreateContextNode = GetOrCreateContextNode.create(code);
+            getOrCreateContextNode = GetOrCreateContextNode.create(code, true);
         }
 
         public PushClosureNode(final PushClosureNode node) {
@@ -99,7 +99,7 @@ public final class PushBytecodes {
             blockSize = node.blockSize;
             popNNode = FrameStackPopNNode.create(code, numCopied);
             pushNode = FrameStackPushNode.create(code);
-            getOrCreateContextNode = GetOrCreateContextNode.create(code);
+            getOrCreateContextNode = GetOrCreateContextNode.create(code, true);
         }
 
         public static PushClosureNode create(final CompiledCodeObject code, final int index, final int numBytecodes, final int i, final int j, final int k) {

--- a/src/de.hpi.swa.graal.squeak/src/de/hpi/swa/graal/squeak/nodes/process/ResumeProcessNode.java
+++ b/src/de.hpi.swa.graal.squeak/src/de/hpi/swa/graal/squeak/nodes/process/ResumeProcessNode.java
@@ -18,6 +18,8 @@ import de.hpi.swa.graal.squeak.nodes.accessing.AbstractPointersObjectNodes.Abstr
 import de.hpi.swa.graal.squeak.nodes.accessing.AbstractPointersObjectNodes.AbstractPointersObjectWriteNode;
 
 public abstract class ResumeProcessNode extends AbstractNodeWithCode {
+    protected static final boolean TRUE = true;
+
     @Child private AbstractPointersObjectReadNode pointersReadNode = AbstractPointersObjectReadNode.create();
     @Child private PutToSleepNode putToSleepNode;
 
@@ -35,7 +37,7 @@ public abstract class ResumeProcessNode extends AbstractNodeWithCode {
     @Specialization(guards = "hasHigherPriority(newProcess)")
     protected final void doTransferTo(final VirtualFrame frame, final PointersObject newProcess,
                     @Cached final AbstractPointersObjectWriteNode pointersWriteNode,
-                    @Cached("create(code)") final GetOrCreateContextNode contextNode) {
+                    @Cached("create(code, TRUE)") final GetOrCreateContextNode contextNode) {
         putToSleepNode.executePutToSleep(code.image.getActiveProcess(pointersReadNode));
         contextNode.executeGet(frame).transferTo(pointersReadNode, pointersWriteNode, newProcess);
     }

--- a/src/de.hpi.swa.graal.squeak/src/de/hpi/swa/graal/squeak/nodes/process/WakeHighestPriorityNode.java
+++ b/src/de.hpi.swa.graal.squeak/src/de/hpi/swa/graal/squeak/nodes/process/WakeHighestPriorityNode.java
@@ -32,7 +32,7 @@ public final class WakeHighestPriorityNode extends AbstractNodeWithImage {
 
     private WakeHighestPriorityNode(final CompiledCodeObject code) {
         super(code.image);
-        contextNode = GetOrCreateContextNode.create(code);
+        contextNode = GetOrCreateContextNode.create(code, true);
     }
 
     public static WakeHighestPriorityNode create(final CompiledCodeObject code) {


### PR DESCRIPTION
For the testcases I also had to fix the doItContext creation - while a doItMethod does not have arguments or copiedValues, it may have temporaries. Also the class is UndefinedObject, but the receiver is nil
